### PR TITLE
Remove -r parameter in the example as the restore if failed is already included

### DIFF
--- a/includes/help.sh
+++ b/includes/help.sh
@@ -23,7 +23,7 @@ echo "-s | sync catalog"
 echo "-p | Prune unused/old docker images"
 echo
 echo -e "${BWhite}Examples${Color_Off}"
-echo "bash truetool.sh -b 14 -i portainer -i arch -i sonarr -i radarr -t 600 -vrsUp"
+echo "bash truetool.sh -b 14 -i portainer -i arch -i sonarr -i radarr -t 600 -vsUp"
 echo "bash /mnt/tank/scripts/truetool.sh -t 150 --mount"
 echo "bash /mnt/tank/scripts/truetool.sh --dns"
 echo "bash /mnt/tank/scripts/truetool.sh --restore"


### PR DESCRIPTION
**Description**

Remove -r parameter as the restore if failed is already included

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

Executed the command without the parameter as it was outputing an error (parameter unrecognized)

**📃 Notes:**

The documentation was not refering to the parameter, only the example.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning