### PR TITLE
Restrict zfs volume lookup to kubernetes dataset

### DIFF
--- a/includes/mount.sh
+++ b/includes/mount.sh
@@ -27,7 +27,8 @@ if [[ $selection == "1" ]]; then
     done
     data_name=$(echo "$pvc" | awk '{print $3}')
     volume_name=$(echo "$pvc" | awk '{print $4}')
-    full_path=$(zfs list | grep "$volume_name" | awk '{print $1}')
+    pool=$(cli -m csv -c 'app kubernetes config' | awk -F ',' 'NR==2 {print $13}' | tr -d " \t\n\r")
+    full_path=$(zfs list -r "$pool" | grep "$volume_name" | awk '{print $1}')
     echo -e "\nMounting\n$full_path\nTo\n/mnt/truetool/$data_name" && zfs set mountpoint="/truetool/$data_name" "$full_path" && echo -e "Mounted, Use the Unmount All option to unmount\n"
     exit
 elif [[ $selection == "2" ]]; then


### PR DESCRIPTION
to avoid matching multiple datasets in the presence of backups of ix-applications.

**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  #33 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
Tested manually on my TrueNAS Scale by issueing
```
pool=$(cli -m csv -c 'app kubernetes config' | awk -F ',' 'NR==2 {print $13}' | tr -d " \t\n\r")
zfs list -r "$pool"
```
and also by patching my local truetool with these changes and mounting a volume.

**📃 Notes:**
<!-- Please enter any other relevant information here -->
`app kubernets config` does not support specifying the columns you want your csv output to have as far as I could see. This means the `print $13` is a little bit brittle in that it will break if a column is added or removed before it.

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
